### PR TITLE
removed override in ComplexiPhiWorld.h evaluateSolo

### DIFF
--- a/experimental/World/ComplexiPhiWorld/ComplexiPhiWorld.h
+++ b/experimental/World/ComplexiPhiWorld/ComplexiPhiWorld.h
@@ -41,7 +41,7 @@ public:
 	
     ComplexiPhiWorld (shared_ptr<ParametersTable> _PT = nullptr);
     virtual ~ComplexiPhiWorld () = default;
-	virtual void evaluateSolo(shared_ptr<Organism> org, int analyse, int visualize, int debug) override;
+	virtual void evaluateSolo(shared_ptr<Organism> org, int analyse, int visualize, int debug);
 	virtual void evaluate(map<string, shared_ptr<Group>>& groups, int analyse, int visualize, int debug) {
 		int popSize = groups[groupNamePL->get(PT)]->population.size();
 		for (int i = 0; i < popSize; i++) {


### PR DESCRIPTION
When trying to compile MABE with ComplexiPhiWorld, an error was thrown because the override was not up to date. Removing the override allows it to compile. 